### PR TITLE
Update npm modules; Remove warnings about loading scripts using docum…

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -16,7 +16,7 @@
       const script = document.createElement('script');
       const port = 8080;
       script.src = (process.env.HOT) ? `http://localhost:${port}/build/bundle.js` : '../build/bundle.js';
-      document.write(script.outerHTML);
+      document.body.appendChild(script);
     }
   </script>
 </html>

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ function createWindow () {
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
     mainWindow = null;
-  })
+  });
 }
 
 // This method will be called when Electron has finished

--- a/package.json
+++ b/package.json
@@ -13,19 +13,19 @@
   "author": "Ethereal Labs",
   "license": "GNU GPLv3",
   "dependencies": {
-    "react": "^0.14.2",
-    "react-dom": "^0.14.2"
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
   },
   "devDependencies": {
-    "babel-core": "^6.1.21",
-    "babel-loader": "^6.1.0",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-react": "^6.1.18",
+    "babel-core": "^6.23.1",
+    "babel-loader": "^6.3.2",
+    "babel-preset-latest": "^6.22.0",
+    "babel-preset-react": "^6.23.0",
     "copy-webpack-plugin": "^0.2.0",
     "cross-env": "^2.0.1",
     "css-loader": "^0.25.0",
-    "electron": "^1.3.4",
-    "electron-packager": "^8.0.0",
+    "electron": "^1.4.15",
+    "electron-packager": "^8.5.1",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "react-hot-loader": "^1.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
         loader: 'babel-loader',
         exclude: /node_modules/,
         query: {
-          presets: ['react', 'es2015']
+          presets: ['react', 'latest']
         }
       },
       { test: /\.css$/, loader: 'style-loader!css-loader' },


### PR DESCRIPTION
## Instructions
Update npm and node and clear old modules. Here's how to do it using `n` on Linux/OSX:
```bash
# Make sure you're in the ethereal-irc dir.
npm i -g n
n latest
n use 7.5.0 # Verify this worked by doing: node -v
npm update -g npm
rm -rf node_modules/
```
Once the above steps are completed and you've pulled in this branch. Run `npm i`.

Verify it worked by starting up the app. There should be no errors when you run `npm run webpack-server`, `npm start`, and there should be no errors in the app's devtools log.